### PR TITLE
Raising ValueError for invalid LLMConfig str.

### DIFF
--- a/notdiamond/llms/config.py
+++ b/notdiamond/llms/config.py
@@ -141,6 +141,10 @@ class LLMConfig:
             LLMConfig: initialized object with correct provider and model
         """
         split_items = llm_provider.split("/")
+        if len(split_items) != 2:
+            raise ValueError(
+                f"Expected string of format 'provider/model' but got {llm_provider}"
+            )
         provider = split_items[0]
         model = split_items[1]
         return cls(provider=provider, model=model)


### PR DESCRIPTION
Caught this while preparing https://github.com/run-llama/llama_index/issues/15161, so this PR handles `LLMConfig` strings a bit more carefully.