### PR TITLE
Adding endpoint config to `NotDiamond` [ENG-965].

### DIFF
--- a/.github/workflows/all-sdk-tests.yml
+++ b/.github/workflows/all-sdk-tests.yml
@@ -58,6 +58,7 @@ jobs:
           REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
           PPLX_API_KEY: ${{ secrets.PPLX_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          NOTDIAMOND_API_URL: ${{ secrets.NOTDIAMOND_API_URL }}
         run: |
           PYTEST_ADDOPTS="--color=yes" poetry run coverage run --branch -m pytest -v tests/
           poetry run coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 .env
 .envrc
 .python-version
+dist/
 !dist/.gitkeep

--- a/notdiamond/llms/client.py
+++ b/notdiamond/llms/client.py
@@ -91,6 +91,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
             preference_id: Optional[str] = None,
             callbacks: Optional[List] = None,
             tools: Optional[Sequence[Union[Dict[str, Any], Callable]]] = None,
+            nd_api_url: Optional[str] = settings.NOTDIAMOND_API_URL,
             **kwargs,
         ):
             if api_key is None:
@@ -126,6 +127,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=preference_id,
                 tools=tools,
                 callbacks=callbacks,
+                nd_api_url=nd_api_url,
                 **kwargs,
             )
 
@@ -179,8 +181,8 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                                                 Defaults to Metric("accuracy").
                 timeout (int): The number of seconds to wait before terminating the API call to Not Diamond backend.
                                 Default to 5 seconds.
+                nd_api_url (Optional[str]): The URL of the NotDiamond API. Defaults to settings.NOTDIAMOND_API_URL.
                 **kwargs: Any other arguments that are supported by Langchain's invoke method, will be passed through.
-
             Returns:
                 tuple[str, Optional[LLMConfig]]: returns the session_id and the chosen LLM
             """
@@ -530,6 +532,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
             preference_id: Optional[str] = None,
             tools: Optional[Sequence[Union[Dict[str, Any], Callable]]] = None,
             callbacks: Optional[List] = None,
+            nd_api_url: Optional[str] = settings.NOTDIAMOND_API_URL,
             **kwargs,
         ) -> None:
             super().__init__(
@@ -543,6 +546,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=preference_id,
                 tools=tools,
                 callbacks=callbacks,
+                nd_api_url=nd_api_url,
                 **kwargs,
             )
 
@@ -616,6 +620,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                                                                 dict.
                 timeout (int): The number of seconds to wait before terminating the API call to Not Diamond backend.
                                 Default to 5 seconds.
+                nd_api_url (Optional[str]): The URL of the NotDiamond API. Defaults to settings.NOTDIAMOND_API_URL.
                 **kwargs: Any other arguments that are supported by Langchain's invoke method, will be passed through.
 
             Raises:
@@ -1641,7 +1646,7 @@ class NotDiamond(_NDClient):
     """Bind tools to the LLM object. The tools will be passed to the LLM object when invoking it."""
 
     nd_api_url: Optional[str]
-    """The URL of the NotDiamond API. Defaults to None."""
+    """The URL of the NotDiamond API. Defaults to settings.NOTDIAMOND_API_URL."""
 
     class Config:
         arbitrary_types_allowed = True

--- a/notdiamond/llms/client.py
+++ b/notdiamond/llms/client.py
@@ -32,7 +32,12 @@ from notdiamond.exceptions import (
     MissingLLMConfigs,
 )
 from notdiamond.llms.config import LLMConfig
-from notdiamond.llms.request import amodel_select, model_select, report_latency, create_preference_id
+from notdiamond.llms.request import (
+    amodel_select,
+    create_preference_id,
+    model_select,
+    report_latency,
+)
 from notdiamond.metrics.metric import Metric
 from notdiamond.prompts import _curly_escape, inject_system_prompt
 from notdiamond.types import NDApiKeyValidator
@@ -132,7 +137,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
             return self
 
         def create_preference_id(self, name: Optional[str] = None) -> str:
-            return create_preference_id(self.api_key, name)
+            return create_preference_id(self.api_key, name, self.nd_api_url)
 
         async def amodel_select(
             self,
@@ -205,6 +210,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             if not best_llm:
@@ -286,6 +292,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             if not best_llm:
@@ -1363,6 +1370,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 llm_config=llm_config,
                 tokens_per_second=tokens_per_second,
                 notdiamond_api_key=self.api_key,
+                nd_api_url=self.nd_api_url,
             )
             self.call_callbacks(
                 "on_latency_tracking",
@@ -1406,6 +1414,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 llm_config=llm_config,
                 tokens_per_second=tokens_per_second,
                 notdiamond_api_key=self.api_key,
+                nd_api_url=self.nd_api_url,
             )
             self.call_callbacks(
                 "on_latency_tracking",
@@ -1625,11 +1634,20 @@ class NotDiamond(_NDClient):
     tools: Optional[Sequence[Union[Dict[str, Any], Callable]]]
     """Bind tools to the LLM object. The tools will be passed to the LLM object when invoking it."""
 
+    nd_api_url: Optional[str]
+    """The URL of the NotDiamond API. Defaults to None."""
+
     class Config:
         arbitrary_types_allowed = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        nd_api_url: Optional[str] = settings.NOTDIAMOND_API_URL,
+        *args,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
+        self.nd_api_url = nd_api_url
 
 
 def _get_accepted_invoke_errors(provider: str) -> Tuple:

--- a/notdiamond/llms/client.py
+++ b/notdiamond/llms/client.py
@@ -74,6 +74,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
         preference_id: Optional[str]
         tools: Optional[Sequence[Union[Dict[str, Any], Callable]]]
         callbacks: Optional[List]
+        nd_api_url: Optional[str]
 
         class Config:
             arbitrary_types_allowed = True
@@ -515,6 +516,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
         preference_id: Optional[str]
         tools: Optional[Sequence[Union[Dict[str, Any], Callable]]]
         callbacks: Optional[List]
+        nd_api_url: Optional[str]
 
         def __init__(
             self,
@@ -806,6 +808,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             is_default = False
@@ -1001,6 +1004,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             is_default = False
@@ -1187,6 +1191,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             if not best_llm:
@@ -1301,6 +1306,7 @@ def _ndllm_factory(import_target: _NDClientTarget = None):
                 preference_id=self.preference_id,
                 tools=self.tools,
                 timeout=timeout,
+                nd_api_url=self.nd_api_url,
             )
 
             if not best_llm:

--- a/notdiamond/llms/request.py
+++ b/notdiamond/llms/request.py
@@ -164,6 +164,7 @@ def model_select(
         tradeoff=tradeoff,
         preference_id=preference_id,
         tools=tools,
+        nd_api_url=nd_api_url,
     )
 
     try:

--- a/notdiamond/metrics/request.py
+++ b/notdiamond/metrics/request.py
@@ -17,8 +17,9 @@ def feedback_request(
     llm_config: LLMConfig,
     feedback_payload: Dict[str, int],
     notdiamond_api_key: str,
+    nd_api_url: str = settings.NOTDIAMOND_API_URL,
 ) -> bool:
-    url = f"{settings.ND_BASE_URL}/v2/report/metrics/feedback"
+    url = f"{nd_api_url}/v2/report/metrics/feedback"
 
     payload: FeedbackRequestPayload = {
         "session_id": session_id,

--- a/notdiamond/settings.py
+++ b/notdiamond/settings.py
@@ -18,7 +18,9 @@ PPLX_API_KEY = os.getenv("PPLX_API_KEY", default="")
 REPLICATE_API_KEY = os.getenv("REPLICATE_API_KEY", default="")
 
 
-ND_BASE_URL = "https://not-diamond-server.onrender.com"
+NOTDIAMOND_API_URL = os.getenv(
+    "ND_BASE_URL", "https://not-diamond-server.onrender.com"
+)
 
 PROVIDERS = {
     "openai": {

--- a/notdiamond/settings.py
+++ b/notdiamond/settings.py
@@ -19,7 +19,7 @@ REPLICATE_API_KEY = os.getenv("REPLICATE_API_KEY", default="")
 
 
 NOTDIAMOND_API_URL = os.getenv(
-    "ND_BASE_URL", "https://not-diamond-server.onrender.com"
+    "NOTDIAMOND_API_URL", "https://not-diamond-server.onrender.com"
 )
 
 PROVIDERS = {

--- a/notdiamond/toolkit/custom_router.py
+++ b/notdiamond/toolkit/custom_router.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from notdiamond.exceptions import ApiError
 from notdiamond.llms.client import NotDiamond
 from notdiamond.llms.config import LLMConfig
-from notdiamond.settings import ND_BASE_URL, NOTDIAMOND_API_KEY, VERSION
+from notdiamond.settings import NOTDIAMOND_API_KEY, NOTDIAMOND_API_URL, VERSION
 from notdiamond.types import NDApiKeyValidator
 
 
@@ -46,8 +46,9 @@ class CustomRouter:
         dataset_file: str,
         llm_configs: List[LLMConfig],
         preference_id: Optional[str],
+        nd_api_url: str,
     ) -> str:
-        url = f"{ND_BASE_URL}/v2/pzn/trainCustomRouter"
+        url = f"{nd_api_url}/v2/pzn/trainCustomRouter"
 
         files = {"dataset_file": open(dataset_file, "rb")}
 
@@ -123,6 +124,7 @@ class CustomRouter:
         response_column: str,
         score_column: str,
         preference_id: Optional[str] = None,
+        nd_api_url: Optional[str] = NOTDIAMOND_API_URL,
     ) -> str:
         """
         Method to train a custom router using provided dataset.
@@ -138,6 +140,7 @@ class CustomRouter:
                 to the score given to the response from the LLM.
             preference_id (Optional[str], optional): If specified, the custom router
                 associated with the preference_id will be updated with the provided dataset.
+            nd_api_url (Optional[str], optional): The URL of the NotDiamond API. Defaults to prod.
 
         Raises:
             ApiError: When the NotDiamond API fails
@@ -157,7 +160,11 @@ class CustomRouter:
         with tempfile.NamedTemporaryFile(suffix=".csv") as joint_csv:
             joint_df.to_csv(joint_csv.name, index=False)
             preference_id = self._request_train_router(
-                prompt_column, joint_csv.name, llm_configs, preference_id
+                prompt_column,
+                joint_csv.name,
+                llm_configs,
+                preference_id,
+                nd_api_url,
             )
 
         return preference_id

--- a/tests/test_llm_calls/test_perplexity.py
+++ b/tests/test_llm_calls/test_perplexity.py
@@ -7,7 +7,7 @@ from notdiamond.metrics.metric import Metric
 
 @pytest.mark.longrun
 class Test_Perplexity_LLMs:
-    def test_llama_3_sonar_large_32k_online(self):
+    def test_llama_3_1_sonar_large_128k_online(self):
         provider = NDLLMProviders.LLAMA_3_1_SONAR_LARGE_128K_ONLINE
         provider.kwargs = {"max_tokens": 10}
         nd_llm = NotDiamond(


### PR DESCRIPTION
Users should have the ability to configure a target API endpoint if they so desire. This will be useful for local deployments, as well as proxy-hosted capabilities.