### PR TITLE
fix rag_workflow run in each trial

### DIFF
--- a/notdiamond/toolkit/rag/workflow.py
+++ b/notdiamond/toolkit/rag/workflow.py
@@ -128,7 +128,6 @@ class BaseNDRagWorkflow:
         self.documents = documents
         self.test_queries = test_queries
         self.objective_maximize = objective_maximize
-        self.evaluation_dataset = self.rag_workflow(documents, test_queries)
 
     def get_parameter_type(self, param_name: str) -> Type:
         param_type = self._base_param_types.get(param_name)
@@ -189,6 +188,9 @@ class BaseNDRagWorkflow:
                 )
             setattr(self, param_name, param_value)
 
+        self.evaluation_dataset = self.rag_workflow(
+            self.documents, self.test_queries
+        )
         result = self.objective()
         self._reset_param_values()
         return result

--- a/tests/test_toolkit/rag/test_example_workflow.py
+++ b/tests/test_toolkit/rag/test_example_workflow.py
@@ -137,4 +137,5 @@ def test_workflow_attrs_init(llamaindex_documents, test_queries):
     example_workflow = ExampleNDRagWorkflow(
         llamaindex_documents, test_queries, objective_maximize=True
     )
-    assert hasattr(example_workflow, "index")
+    assert hasattr(example_workflow, "test_queries")
+    assert hasattr(example_workflow, "documents")


### PR DESCRIPTION
Move the `evaluation_dataset` creation to `_outer_objective` in order to reinitialise on each objective computation