### PR TITLE
chore: update dependencies in poetry.lock and pyproject.toml, bumping urllib3 to 2.6.2 and langchain-core to 0.3.80

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2713,25 +2713,25 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10"
 
 [[package]]
 name = "langchain-core"
-version = "0.3.76"
+version = "0.3.80"
 description = "Building applications with LLMs through composability"
 optional = true
-python-versions = ">=3.9"
+python-versions = "<4.0.0,>=3.9.0"
 groups = ["main"]
 markers = "extra == \"create\" or extra == \"rag\""
 files = [
-    {file = "langchain_core-0.3.76-py3-none-any.whl", hash = "sha256:46e0eb48c7ac532432d51f8ca1ece1804c82afe9ae3dcf027b867edadf82b3ec"},
-    {file = "langchain_core-0.3.76.tar.gz", hash = "sha256:71136a122dd1abae2c289c5809d035cf12b5f2bb682d8a4c1078cd94feae7419"},
+    {file = "langchain_core-0.3.80-py3-none-any.whl", hash = "sha256:2141e3838d100d17dce2359f561ec0df52c526bae0de6d4f469f8026c5747456"},
+    {file = "langchain_core-0.3.80.tar.gz", hash = "sha256:29636b82513ab49e834764d023c4d18554d3d719a185d37b019d0a8ae948c6bb"},
 ]
 
 [package.dependencies]
-jsonpatch = ">=1.33,<2.0"
-langsmith = ">=0.3.45"
-packaging = ">=23.2"
-pydantic = ">=2.7.4"
-PyYAML = ">=5.3"
+jsonpatch = ">=1.33.0,<2.0.0"
+langsmith = ">=0.3.45,<1.0.0"
+packaging = ">=23.2.0,<26.0.0"
+pydantic = ">=2.7.4,<3.0.0"
+PyYAML = ">=5.3.0,<7.0.0"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
-typing-extensions = ">=4.7"
+typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
 name = "langchain-google-genai"
@@ -7160,22 +7160,22 @@ Pillow = ">=8.0.0"
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev", "test"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
+    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
 ]
 markers = {test = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "vcrpy"
@@ -7833,4 +7833,4 @@ rag = ["langchain", "langchain-anthropic", "langchain-cohere", "langchain-commun
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.10,<3.13"
-content-hash = "9b8e6bb237f19e0a997c540b1a298d6ac177c04d48c177b2004ec1c132d83f22"
+content-hash = "5e906d76972a39c2e55c6ccb7a9de7b22afb836eedb28e6b46a0da500f8ab5f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ langchain-mistralai = { version = ">=0.2.10", optional = true }
 langchain-together = { version = ">=0.3.0", optional = true }
 langchain-cohere = { version = ">=0.4.3", optional = true }
 requests = ">=2.31"
-urllib3 = ">=2.5.0"
+urllib3 = ">=2.6.0"
 transformers = { version = ">=4.53.0", optional = true }
 pypdf = { version = ">=6.1.3", optional = true }
 openai = { version = ">=1.66.3", optional = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates dependency versions and constraints, notably upgrading urllib3 and langchain-core and aligning related version bounds and extras.
> 
> - **Dependencies**:
>   - **Upgrades**:
>     - `langchain-core` → `0.3.80` with tightened deps (`jsonpatch`, `langsmith`, `packaging`, `pydantic`, `PyYAML`, `typing-extensions`, `tenacity`).
>     - `urllib3` → `2.6.2` with updated extras (`brotli`, `zstd`).
>   - **Constraints**:
>     - In `pyproject.toml`, raise `urllib3` minimum to `>=2.6.0`.
> - **Lockfile**:
>   - Refresh `poetry.lock` entries and metadata content hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da82409c48e4b5a650997b03698385690b0c796e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->